### PR TITLE
fix: add version "version": "1.1.0" to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "tig/postcode-magento2",
   "description": "TIG Magento 2 Postcode extension",
+  "version": "1.1.0",
   "require": {
     "php": "~7.0|~7.1",
     "magento/framework": ">=100.1.0,<=100.1.12|>=101.0.0,<=101.0.3"


### PR DESCRIPTION
This extension can't be installed with composer without version being in composer.json file 