### PR TITLE
Added a fix for action to allow dynamic location of tig_housenumber

### DIFF
--- a/view/frontend/web/js/action/set-billing-address-mixin.js
+++ b/view/frontend/web/js/action/set-billing-address-mixin.js
@@ -64,11 +64,11 @@ define([
             }
             // >= M2.3.0
             if (billingAddress.customAttributes.length > 0) {
-                billingAddress.customAttributes.forEach(function(element) {
-                    if(element.customAttributes.attribute_code === 'tig_housenumber') {
-                        billingAddress['extension_attributes']['tig_housenumber']       = element.customAttributes.value;
-                    } else if (element.customAttributes.attribute_code === 'tig_housenumber_addition') {
-                        billingAddress['extension_attributes']['tig_housenumber_addition'] = element.customAttributes.value;
+                billingAddress.customAttributes.forEach(function(customAttribute) {
+                    if(customAttribute.attribute_code === 'tig_housenumber') {
+                        billingAddress['extension_attributes']['tig_housenumber']           = customAttribute.value;
+                    } else if (customAttribute.attribute_code === 'tig_housenumber_addition') {
+                        billingAddress['extension_attributes']['tig_housenumber_addition']  = customAttribute.value;
                     }
                 });
             }

--- a/view/frontend/web/js/action/set-billing-address-mixin.js
+++ b/view/frontend/web/js/action/set-billing-address-mixin.js
@@ -63,9 +63,14 @@ define([
                 return originalAction();
             }
             // >= M2.3.0
-            if (billingAddress.customAttributes[0] !== undefined && billingAddress.customAttributes[0].attribute_code === 'tig_housenumber') {
-                billingAddress['extension_attributes']['tig_housenumber']          = billingAddress.customAttributes[0].value;
-                billingAddress['extension_attributes']['tig_housenumber_addition'] = billingAddress.customAttributes[1].value;
+            if (billingAddress.customAttributes.length > 0) {
+                billingAddress.customAttributes.forEach(function(element) {
+                    if(element.customAttributes.attribute_code === 'tig_housenumber') {
+                        billingAddress['extension_attributes']['tig_housenumber']       = element.customAttributes.value;
+                    } else if (element.customAttributes.attribute_code === 'tig_housenumber_addition') {
+                        billingAddress['extension_attributes']['tig_housenumber_addition'] = element.customAttributes.value;
+                    }
+                });
             }
 
             return originalAction();

--- a/view/frontend/web/js/action/set-shipping-information-mixin.js
+++ b/view/frontend/web/js/action/set-shipping-information-mixin.js
@@ -64,11 +64,11 @@ define([
             }
             // >= M2.3.0
             if (shippingAddress.customAttributes.length > 0) {
-                shippingAddress.customAttributes.forEach(function(element) {
-                    if(element.customAttributes.attribute_code === 'tig_housenumber') {
-                        shippingAddress['extension_attributes']['tig_housenumber']       = element.customAttributes.value;
-                    } else if (element.customAttributes.attribute_code === 'tig_housenumber_addition') {
-                        shippingAddress['extension_attributes']['tig_housenumber_addition'] = element.customAttributes.value;
+                shippingAddress.customAttributes.forEach(function(customAttribute) {
+                    if(customAttribute.attribute_code === 'tig_housenumber') {
+                        shippingAddress['extension_attributes']['tig_housenumber']       = customAttribute.value;
+                    } else if (customAttribute.attribute_code === 'tig_housenumber_addition') {
+                        shippingAddress['extension_attributes']['tig_housenumber_addition'] = customAttribute.value;
                     }
                 });
             }

--- a/view/frontend/web/js/action/set-shipping-information-mixin.js
+++ b/view/frontend/web/js/action/set-shipping-information-mixin.js
@@ -63,9 +63,14 @@ define([
                 return originalAction();
             }
             // >= M2.3.0
-            if (shippingAddress.customAttributes[0] !== undefined && shippingAddress.customAttributes[0].attribute_code === 'tig_housenumber') {
-                shippingAddress['extension_attributes']['tig_housenumber']          = shippingAddress.customAttributes[0].value;
-                shippingAddress['extension_attributes']['tig_housenumber_addition'] = shippingAddress.customAttributes[1].value;
+            if (shippingAddress.customAttributes.length > 0) {
+                shippingAddress.customAttributes.forEach(function(element) {
+                    if(element.customAttributes.attribute_code === 'tig_housenumber') {
+                        shippingAddress['extension_attributes']['tig_housenumber']       = element.customAttributes.value;
+                    } else if (element.customAttributes.attribute_code === 'tig_housenumber_addition') {
+                        shippingAddress['extension_attributes']['tig_housenumber_addition'] = element.customAttributes.value;
+                    }
+                });
             }
 
             return originalAction();

--- a/view/frontend/web/js/view/form/fields.js
+++ b/view/frontend/web/js/view/form/fields.js
@@ -76,9 +76,12 @@ define([
                     address.extension_attributes = {};
                 }
 
-                if (address.customAttributes !== undefined && address.customAttributes[0] !== undefined && address.customAttributes[0].attribute_code === 'tig_housenumber') {
-                    address.extension_attributes.tig_housenumber          = address.customAttributes[0].value;
-                    address.extension_attributes.tig_housenumber_addition = address.customAttributes[1].value;
+                for(let attribute in address.customAttributes) {
+                    if(address.customAttributes[attribute].attribute_code === 'tig_housenumber') {
+                        address.extension_attributes.tig_housenumber = address.customAttributes[attribute].value;
+                    } else if (address.customAttributes[attribute].attribute_code === 'tig_housenumber_addition') {
+                        address.extension_attributes.tig_housenumber_addition = address.customAttributes[attribute].value;
+                    }
                 }
             });
 


### PR DESCRIPTION
### Make sure you are using the *latest* version: https://tig.nl/totale-aanbod-extensies/postcode-service-magento-2/
Issues with outdated version will be rejected.
- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG Buckaroo Magento extension.

---

### What is the purpose of your *issue*?
- [x] Bug report (encountered problems with the TIG Buckaroo Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [ ] Other

---

### Description of your *issue*, suggested solution and other information

We had a use case where during checkout the `customAttributes` could contain more elements than `tig_housenumber` and or `tig_housenumber_addition`. It also appeared that another `customAttributes` element was before the `tig_housenumber`. What happened afterwards was that no house numbers were added into the order.

After looking into the code we noticed there was a direct array acces to the 0th element. So it assumed that the `tig_housenumber` was always the 0th element. 
```
if (billingAddress.customAttributes[0] !== undefined && billingAddress.customAttributes[0].attribute_code === 'tig_housenumber') {
```
Which could be not true as it was in our case. This can be wherever depending on many different factors. In our case we had a custom attribute to enable a custom field for business or consumer dropdown.

The pull request has the fix to be able to load the attributes dynamically and add them to `extension_attributes`.

### Support TIG

On Github we will respond in English even when the question was asked in Dutch.
