### PR TITLE
Prevent loading all jquery ui modules on every page

### DIFF
--- a/view/frontend/web/js/lib/mage/mage-mixin.js
+++ b/view/frontend/web/js/lib/mage/mage-mixin.js
@@ -33,7 +33,7 @@
  */
 define([
     'jquery',
-    'jquery/ui'
+    'jquery-ui-modules/menu',
 ], function ($) {
     'use strict';
 

--- a/view/frontend/web/js/lib/mage/mage-mixin.js
+++ b/view/frontend/web/js/lib/mage/mage-mixin.js
@@ -33,7 +33,7 @@
  */
 define([
     'jquery',
-    'jquery-ui-modules/menu',
+    'jquery-ui-modules/menu'
 ], function ($) {
     'use strict';
 


### PR DESCRIPTION
Prevent loading all jquery ui modules by only loading the needed jquery ui module (since M2.3.3)

### Submitting issues trough Github
## Please follow the guide below

- You will be asked some questions and requested to provide some information, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *issue* (like this: `[x]`)
- Use the *Preview* tab to see what your issue will actually look like

---

### Make sure you are using the *latest* version: https://github.com/tig-nl/postcode-magento2/releases/
Issues with outdated version will be rejected.
- [ x ] I've **verified** and **I assure** that I'm running the latest version of the TIG Postcode Magento extension.

---

### What is the purpose of your *issue*?
- [ ] Bug report (encountered problems with the TIG Buckaroo Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [ x ] Other (suggested improvement)

---

### Description of your *issue*, suggested solution and other information

Currently the menu widget 'mage/menu' is put inside a mixin in your module, which is loaded on every page. It depends on 'jquery/ui', which triggers all jquery ui modules to load - slowing down each page.

As of Magento 2.3.3 all jquery ui modules have been added to Magento2 separately, and a browser console will show a notice on each page: "compat.js:43 Fallback to JQueryUI Compat activated. Your store is missing a dependency for a jQueryUI widget. Identifying and addressing the dependency will drastically improve the performance of your site"

The menu widget in the Magento core has been updated to require 'jquery-ui-modules/menu', allowing the same improvement in your mixin.


### Support TIG

On Github we will respond in English even when the question was asked in Dutch.
