### PR TITLE
Fix unsecure usage of address data

### DIFF
--- a/view/frontend/web/js/view/billing-address-mixin.js
+++ b/view/frontend/web/js/view/billing-address-mixin.js
@@ -40,7 +40,8 @@ define([
     return function (Component) {
         return Component.extend({
             tigHouseNumber: function () {
-                if (quote.billingAddress().customAttributes.length > 0) {
+                var customAttributes = quote.billingAddress().customAttributes;
+                if (customAttributes && customAttributes.length > 0) {
                     var houseNumber = "";
                     var houseNumberAddition = "";
 

--- a/view/frontend/web/template/billing-address/details.html
+++ b/view/frontend/web/template/billing-address/details.html
@@ -7,7 +7,7 @@
 <div if="isAddressDetailsVisible() && currentBillingAddress()" class="billing-address-details">
     <text args="currentBillingAddress().prefix"/> <text args="currentBillingAddress().firstname"/> <text args="currentBillingAddress().middlename"/>
     <text args="currentBillingAddress().lastname"/> <text args="currentBillingAddress().suffix"/><br/>
-    <text args="currentBillingAddress().street.join(', ')"/>
+    <text args="currentBillingAddress().street.join(', ')" if="currentBillingAddress().street"/>
     <text args="tigHouseNumber()"/><br/>
     <text args="currentBillingAddress().city "/>, <span text="currentBillingAddress().region"></span> <text args="currentBillingAddress().postcode"/><br/>
     <text args="getCountryName(currentBillingAddress().countryId)"/><br/>

--- a/view/frontend/web/template/shipping-address/address-renderer/default.html
+++ b/view/frontend/web/template/shipping-address/address-renderer/default.html
@@ -7,7 +7,7 @@
 <div class="shipping-address-item" data-bind="css: isSelected() ? 'selected-item' : 'not-selected-item'">
     <text args="address().prefix"/> <text args="address().firstname"/> <text args="address().middlename"/>
     <text args="address().lastname"/> <text args="address().suffix"/><br/>
-    <text args="address().street.join(', ')"/>
+    <text args="address().street.join(', ')" if="address().street"/>
     <each args="data: address().customAttributes, as: 'element'">
         <div class="tig-billing-housenumber" if="element['attribute_code'] == 'tig_housenumber' || element['attribute_code'] == 'tig_housenumber_addition'">
             <text args="element.value"/>

--- a/view/frontend/web/template/shipping-information/address-renderer/default.html
+++ b/view/frontend/web/template/shipping-information/address-renderer/default.html
@@ -7,7 +7,7 @@
 <if args="visible()">
     <text args="address().prefix"/> <text args="address().firstname"/> <text args="address().middlename"/>
     <text args="address().lastname"/> <text args="address().suffix"/><br/>
-    <text args="address().street.join(', ')"/>
+    <text args="address().street.join(', ')" if="address().street"/>
     <each args="data: address().customAttributes, as: 'element'">
         <if args="element['attribute_code'] == 'tig_housenumber' || element['attribute_code'] == 'tig_housenumber_addition'">
             <text args="element.value"/>


### PR DESCRIPTION

- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG Postcode Magento 2 extension.

---

### What is the purpose of your *issue*?
- [x] Bug report (encountered problems with the TIG Postcode Magento 2 extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [ ] Other

---

### Description of your *issue*, suggested solution and other information

When a (guest) user enters the checkout, billing and shipping addresses may not exist yet. In several places of the front-end codebase, this is not taken into account. 

### Support TIG

On Github we will respond in English even when the question was asked in Dutch.
